### PR TITLE
Update constants.js

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -19,7 +19,7 @@ exports.StarBoardCreateDefaultsOptions = {
 	starEmbed: true,
 	resolveImageUrl: true,
 	attachments: true,
-	threshold: 1,
+	threshold: 3,
 	color: '#f1c40f',
 	allowNsfw: false,
 };


### PR DESCRIPTION
Kind of broken when you can't change the threshold when you host it since you can't access the modules on some common hosting sites like repl.it and heroku