### PR TITLE
fix: take star threshold into account for color gradient

### DIFF
--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -145,7 +145,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor((stars - threshold + 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -1,4 +1,4 @@
-const { MessageEmbed, MessageAttachment } = require('discord.js');
+const { MessageEmbed } = require('discord.js');
 const axios = require('axios');
 const cheerio = require('cheerio').default;
 
@@ -74,9 +74,8 @@ module.exports = async (manager, emoji, message, user) => {
 		if(message.cleanContent) content = message.cleanContent.length > 2000 ? message.cleanContent.slice(0, 2000) + '\n...' : message.cleanContent;
 		else content = embedContent ? embedContent : '';
 
-		let isAttachedImage = false;
+
 		let image = data.options.attachments ? (message.attachments.size > 0 ? await extension([...message.attachments.values()][0].url) : '') : '';
-		if (image) isAttachedImage = true;
 		if(image === '') image = embedImage ? embedImage.url ? embedImage.url : '' : '';
 		if(image === '' && data.options.resolveImageUrl) {
 			const regex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -108,25 +107,9 @@ module.exports = async (manager, emoji, message, user) => {
 			.setDescription(`${content}\n${image === 'attachment' ? '[attachment]\n' : ''}\n[${manager.options.translateClickHere(message)}](${message.url})`)
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
-			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl });
-
-		if (image) {
-			if (!isAttachedImage) {
-				starEmbed.setImage(image !== 'attachment' ? image : '');
-				starChannel.send({ embeds: [starEmbed] });
-			}
-			else {
-				const res = await axios.get(image, {
-					responseType: 'stream',
-				});
-				const ext = image.split(/[#?]/)[0].split('.').pop().trim();
-				const attach = new MessageAttachment(res.data, `image.${ext}`);
-				starEmbed
-					.setImage('attachment://image.${ext}');
-				starChannel.send({ embeds: [starEmbed], files: [attach] });
-			}
-		}
-
+			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl })
+			.setImage(image !== 'attachment' ? image : '');
+		starChannel.send({ embeds: [starEmbed] });
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}
 
@@ -135,7 +118,7 @@ module.exports = async (manager, emoji, message, user) => {
 function extension(attachment) {
 	const imageLink = attachment.split('.');
 	const typeOfImage = imageLink[imageLink.length - 1];
-	const image = /(jpg|jpeg|png|gif|webp)/gi.test(typeOfImage);
+	const image = /(jpg|jpeg|png|gif)/gi.test(typeOfImage);
 	if (!image) return 'attachment';
 	return attachment;
 }

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -1,4 +1,4 @@
-const { MessageEmbed } = require('discord.js');
+const { MessageEmbed, MessageAttachment } = require('discord.js');
 const axios = require('axios');
 const cheerio = require('cheerio').default;
 
@@ -74,8 +74,9 @@ module.exports = async (manager, emoji, message, user) => {
 		if(message.cleanContent) content = message.cleanContent.length > 2000 ? message.cleanContent.slice(0, 2000) + '\n...' : message.cleanContent;
 		else content = embedContent ? embedContent : '';
 
-
+		let isAttachedImage = false;
 		let image = data.options.attachments ? (message.attachments.size > 0 ? await extension([...message.attachments.values()][0].url) : '') : '';
+		if (image) isAttachedImage = true;
 		if(image === '') image = embedImage ? embedImage.url ? embedImage.url : '' : '';
 		if(image === '' && data.options.resolveImageUrl) {
 			const regex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -107,9 +108,25 @@ module.exports = async (manager, emoji, message, user) => {
 			.setDescription(`${content}\n${image === 'attachment' ? '[attachment]\n' : ''}\n[${manager.options.translateClickHere(message)}](${message.url})`)
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
-			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl })
-			.setImage(image !== 'attachment' ? image : '');
-		starChannel.send({ embeds: [starEmbed] });
+			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl });
+
+		if (image) {
+			if (!isAttachedImage) {
+				starEmbed.setImage(image !== 'attachment' ? image : '');
+				starChannel.send({ embeds: [starEmbed] });
+			}
+			else {
+				const res = await axios.get(image, {
+					responseType: 'stream',
+				});
+				const ext = image.split(/[#?]/)[0].split('.').pop().trim();
+				const attach = new MessageAttachment(res.data, `image.${ext}`);
+				starEmbed
+					.setImage(`attachment://image.${ext}`);
+				starChannel.send({ embeds: [starEmbed], files: [attach] });
+			}
+		}
+
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}
 
@@ -118,7 +135,7 @@ module.exports = async (manager, emoji, message, user) => {
 function extension(attachment) {
 	const imageLink = attachment.split('.');
 	const typeOfImage = imageLink[imageLink.length - 1];
-	const image = /(jpg|jpeg|png|gif)/gi.test(typeOfImage);
+	const image = /(jpg|jpeg|png|gif|webp)/gi.test(typeOfImage);
 	if (!image) return 'attachment';
 	return attachment;
 }

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -1,4 +1,4 @@
-const { MessageEmbed, MessageAttachment } = require('discord.js');
+const { MessageEmbed } = require('discord.js');
 const axios = require('axios');
 const cheerio = require('cheerio').default;
 
@@ -74,9 +74,8 @@ module.exports = async (manager, emoji, message, user) => {
 		if(message.cleanContent) content = message.cleanContent.length > 2000 ? message.cleanContent.slice(0, 2000) + '\n...' : message.cleanContent;
 		else content = embedContent ? embedContent : '';
 
-		let isAttachedImage = false;
+
 		let image = data.options.attachments ? (message.attachments.size > 0 ? await extension([...message.attachments.values()][0].url) : '') : '';
-		if (image) isAttachedImage = true;
 		if(image === '') image = embedImage ? embedImage.url ? embedImage.url : '' : '';
 		if(image === '' && data.options.resolveImageUrl) {
 			const regex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -108,25 +107,9 @@ module.exports = async (manager, emoji, message, user) => {
 			.setDescription(`${content}\n${image === 'attachment' ? '[attachment]\n' : ''}\n[${manager.options.translateClickHere(message)}](${message.url})`)
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
-			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl });
-
-		if (image) {
-			if (!isAttachedImage) {
-				starEmbed.setImage(image !== 'attachment' ? image : '');
-				starChannel.send({ embeds: [starEmbed] });
-			}
-			else {
-				const res = await axios.get(image, {
-					responseType: 'stream',
-				});
-				const ext = image.split(/[#?]/)[0].split('.').pop().trim();
-				const attach = new MessageAttachment(res.data, `image.${ext}`);
-				starEmbed
-					.setImage(`attachment://image.${ext}`);
-				starChannel.send({ embeds: [starEmbed], files: [attach] });
-			}
-		}
-
+			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl })
+			.setImage(image !== 'attachment' ? image : '');
+		starChannel.send({ embeds: [starEmbed] });
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}
 
@@ -135,7 +118,7 @@ module.exports = async (manager, emoji, message, user) => {
 function extension(attachment) {
 	const imageLink = attachment.split('.');
 	const typeOfImage = imageLink[imageLink.length - 1];
-	const image = /(jpg|jpeg|png|gif|webp)/gi.test(typeOfImage);
+	const image = /(jpg|jpeg|png|gif)/gi.test(typeOfImage);
 	if (!image) return 'attachment';
 	return attachment;
 }

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -126,7 +126,6 @@ module.exports = async (manager, emoji, message, user) => {
 				starChannel.send({ embeds: [starEmbed], files: [attach] });
 			}
 		}
-		else starChannel.send({ embeds: [starEmbed] });
 
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -145,7 +145,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(Math.min(stars - threshold, 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -126,6 +126,7 @@ module.exports = async (manager, emoji, message, user) => {
 				starChannel.send({ embeds: [starEmbed], files: [attach] });
 			}
 		}
+		else starChannel.send({ embeds: [starEmbed] });
 
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -145,7 +145,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor((stars - threshold + 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor(Math.min(stars - threshold, 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -43,7 +43,7 @@ module.exports = async (manager, emoji, message, user) => {
 		const count = reaction && reaction.count ? reaction.count : parseInt(stars[2]) + 1;
 
 		const starEmbed = new MessageEmbed()
-			.setColor(getColor(data.options.color, count) || foundStar.color)
+			.setColor(getColor(data.options.color, count, data.options.threshold) || foundStar.color)
 			.setDescription(foundStar.description || '')
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
@@ -123,11 +123,11 @@ function extension(attachment) {
 	return attachment;
 }
 
-function getColor(color, stars = 1) {
+function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(stars - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -145,7 +145,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor(Math.min(stars - threshold, 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -1,4 +1,4 @@
-const { MessageEmbed } = require('discord.js');
+const { MessageEmbed, MessageAttachment } = require('discord.js');
 const axios = require('axios');
 const cheerio = require('cheerio').default;
 
@@ -74,8 +74,9 @@ module.exports = async (manager, emoji, message, user) => {
 		if(message.cleanContent) content = message.cleanContent.length > 2000 ? message.cleanContent.slice(0, 2000) + '\n...' : message.cleanContent;
 		else content = embedContent ? embedContent : '';
 
-
+		let isAttachedImage = false;
 		let image = data.options.attachments ? (message.attachments.size > 0 ? await extension([...message.attachments.values()][0].url) : '') : '';
+		if (image) isAttachedImage = true;
 		if(image === '') image = embedImage ? embedImage.url ? embedImage.url : '' : '';
 		if(image === '' && data.options.resolveImageUrl) {
 			const regex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -107,9 +108,25 @@ module.exports = async (manager, emoji, message, user) => {
 			.setDescription(`${content}\n${image === 'attachment' ? '[attachment]\n' : ''}\n[${manager.options.translateClickHere(message)}](${message.url})`)
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
-			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl })
-			.setImage(image !== 'attachment' ? image : '');
-		starChannel.send({ embeds: [starEmbed] });
+			.setFooter({ text: `${emoji.length > 5 ? '' : data.options.emoji} ${reaction && reaction.count ? reaction.count : 1} | ${message.id}`, iconURL: footerUrl });
+
+		if (image) {
+			if (!isAttachedImage) {
+				starEmbed.setImage(image !== 'attachment' ? image : '');
+				starChannel.send({ embeds: [starEmbed] });
+			}
+			else {
+				const res = await axios.get(image, {
+					responseType: 'stream',
+				});
+				const ext = image.split(/[#?]/)[0].split('.').pop().trim();
+				const attach = new MessageAttachment(res.data, `image.${ext}`);
+				starEmbed
+					.setImage('attachment://image.${ext}');
+				starChannel.send({ embeds: [starEmbed], files: [attach] });
+			}
+		}
+
 		manager.emit('starboardReactionAdd', emoji, message, user);
 	}
 
@@ -118,7 +135,7 @@ module.exports = async (manager, emoji, message, user) => {
 function extension(attachment) {
 	const imageLink = attachment.split('.');
 	const typeOfImage = imageLink[imageLink.length - 1];
-	const image = /(jpg|jpeg|png|gif)/gi.test(typeOfImage);
+	const image = /(jpg|jpeg|png|gif|webp)/gi.test(typeOfImage);
 	if (!image) return 'attachment';
 	return attachment;
 }

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -145,7 +145,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(Math.min(stars - threshold, 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor((stars - threshold + 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionRemove.js
+++ b/src/handlers/reactionRemove.js
@@ -26,7 +26,7 @@ module.exports = async (manager, emoji, message, user) => {
 		const image = foundStar.image && foundStar.image.url || '';
 		const footerUrl = emoji.length > 5 ? `https://cdn.discordapp.com/emojis/${emoji}` : null;
 		const starEmbed = new MessageEmbed()
-			.setColor(getColor(data.options.color, parseInt(stars[2]) - 1) || foundStar.color)
+			.setColor(getColor(data.options.color, parseInt(stars[2]) - 1, data.options.threshold) || foundStar.color)
 			.setDescription(foundStar.description || '')
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
@@ -47,11 +47,11 @@ module.exports = async (manager, emoji, message, user) => {
 
 };
 
-function getColor(color, stars = 1) {
+function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(stars - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(Math.floor((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 


### PR DESCRIPTION
When threshold is >1, gradient calculation doesn't take threshold into account. The "minimum" color of a gradient is often not the defined start of the gradient, depending on starboard config. 

Fix works well in preliminary testing, but haven't extensively tested/