### PR TITLE
feat: take into account threshold for gradient calc

### DIFF
--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -127,7 +127,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(~~((stars - threshold + 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionAdd.js
+++ b/src/handlers/reactionAdd.js
@@ -43,7 +43,7 @@ module.exports = async (manager, emoji, message, user) => {
 		const count = reaction && reaction.count ? reaction.count : parseInt(stars[2]) + 1;
 
 		const starEmbed = new MessageEmbed()
-			.setColor(getColor(data.options.color, count) || foundStar.color)
+			.setColor(getColor(data.options.color, count, data.options.threshold) || foundStar.color)
 			.setDescription(foundStar.description || '')
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
@@ -103,7 +103,7 @@ module.exports = async (manager, emoji, message, user) => {
 
 		const footerUrl = emoji.length > 5 ? `https://cdn.discordapp.com/emojis/${emoji}` : null;
 		const starEmbed = new MessageEmbed()
-			.setColor(getColor(data.options.color))
+			.setColor(getColor(data.options.color, data.options.threshold, data.options.threshold))
 			.setDescription(`${content}\n${image === 'attachment' ? '[attachment]\n' : ''}\n[${manager.options.translateClickHere(message)}](${message.url})`)
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
@@ -123,11 +123,11 @@ function extension(attachment) {
 	return attachment;
 }
 
-function getColor(color, stars = 1) {
+function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(stars - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionRemove.js
+++ b/src/handlers/reactionRemove.js
@@ -51,7 +51,7 @@ function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(~~((stars - threshold + 1) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 

--- a/src/handlers/reactionRemove.js
+++ b/src/handlers/reactionRemove.js
@@ -26,7 +26,7 @@ module.exports = async (manager, emoji, message, user) => {
 		const image = foundStar.image && foundStar.image.url || '';
 		const footerUrl = emoji.length > 5 ? `https://cdn.discordapp.com/emojis/${emoji}` : null;
 		const starEmbed = new MessageEmbed()
-			.setColor(getColor(data.options.color, parseInt(stars[2]) - 1) || foundStar.color)
+			.setColor(getColor(data.options.color, parseInt(stars[2]) - 1, data.options.threshold) || foundStar.color)
 			.setDescription(foundStar.description || '')
 			.setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL() })
 			.setTimestamp()
@@ -47,11 +47,11 @@ module.exports = async (manager, emoji, message, user) => {
 
 };
 
-function getColor(color, stars = 1) {
+function getColor(color, stars = 1, threshold) {
 	if(typeof color === 'string') return color;
 
 	else if (typeof color === 'object' && color.colors && color.max) {
-		const indice = Math.max(Math.min(Math.floor(stars - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
+		const indice = Math.max(Math.min(~~((stars - threshold) - 1 / color.max * color.colors.length), color.colors.length - 1), 0);
 		return color.colors[indice];
 	}
 


### PR DESCRIPTION
When threshold is >1, gradient calculation doesn't take threshold into account. The "minimum" color of a gradient is often not the defined start of the gradient, depending on starboard config.

Fix works well in preliminary testing, but haven't extensively tested.

Also switches from `Math.floor` to bitwise flooring (`~~`), due to `Math.floor` not working properly with negatives